### PR TITLE
If not a generator or promise, just emit run as tape does

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ tape.Test.prototype.run = function run() {
   }
 
   if (!this._deferred) {
+    this._end();
     this.emit('run');
   }
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ tape.Test.prototype.run = function run() {
   }
 
   if (!this._deferred) {
-    return success();
+    this.emit('run');
   }
 
   return true;


### PR DESCRIPTION
Want tests to work just like normal tape when not using generators. 
Any reason why `setImmediate` is used for non deferrered tests?

https://github.com/substack/tape/blob/v4.5.1/lib/test.js#L81

``` javascript
test("blah", (t) => {
t.plan(1);
something(() => t.equals(1,1)); // this still works like normal tape
});
```

TODO: add tests
