### PR TITLE
Ensure tape-async works the same as tape for non-generator functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ process.on('uncaughtException', err => {
   process.exit(-1);
 });
 
-
 process.on('unhandledRejection', err => {
   process.stderr.write(`\nUnhandled rejection occurred. One of your test may have failed silently.\n${err.stack}\n`);
   process.exit(-1);
@@ -70,7 +69,6 @@ tape.Test.prototype.run = function run() {
   }
 
   if (!this._deferred) {
-    this._end();
     this.emit('run');
   }
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ Test suite fails with a generic error message and a stack trace.
 
   test.only('this test will be the only one', t => {
     t.equal(42, 42);
+    t.end();
   });
 ```
 

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ test('support async await functions', function *(t) {
 
 test('test.only is a function', function(t) {
   t.equal(typeof test.only, 'function');
+  t.end();
 });
 
 
@@ -100,24 +101,35 @@ test('support sync function with plan', function(t) {
   t.equal(result, 42);
 });
 
-test('support arrows with plan', t => {
-  t.plan(1);
-  const result = 42;
+test('support generators without explicit end', function *(t) {
+  const result = yield Promise.resolve(42);
   t.equal(result, 42);
 });
 
-test('support generators', function *(t) {
+test('support generators with explicit end', function *(t) {
   const result = yield Promise.resolve(42);
   t.equal(result, 42);
+  t.end();
 });
 
 test('support sync function', function(t) {
   const result = 42;
   t.equal(result, 42);
+  t.end();
 });
 
-test('support arrows', t => {
+test('support async function', function(t) {
   const result = 42;
-  t.equal(result, 42);
+  process.nextTick(() => {
+    t.equal(result, 42);
+    t.end();
+  });
 });
 
+test('support async function with plan', function(t) {
+  const result = 42;
+  t.plan(1);
+  process.nextTick(() => {
+    t.equal(result, 42);
+  });
+});


### PR DESCRIPTION
- Removed call to this._end() from PR #2
- Removed some unnecessary(?) arrow function tests
- Fixed tests when this._end() was removed
- Added new tests for normal tape async tests
