### PR TITLE
await inside t.throws async function does not work:

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
 const tape = require('tape');
 const isGenerator = require('is-generator');
 const isPromise = require('is-promise');
+const defined = require('defined');
+const bind = require('function-bind');
+const has = require('has');
+const isEnumerable = bind.call(Function.call, Object.prototype.propertyIsEnumerable);
 const co = require('co');
 
 module.exports = tape;
@@ -73,4 +77,67 @@ tape.Test.prototype.run = function run() {
   }
 
   return true;
+};
+
+tape.Test.prototype.throws = async function (fn, expected, msg, extra) {
+  if (typeof expected === 'string') {
+    msg = expected;
+    expected = undefined;
+  }
+
+  var caught = undefined;
+
+  try {
+    await fn();
+  } catch (err) {
+    caught = { error : err };
+    if ((err != null) && (!isEnumerable(err, 'message') || !has(err, 'message'))) {
+      var message = err.message;
+      delete err.message;
+      err.message = message;
+    }
+  }
+
+  var passed = caught;
+
+  if (expected instanceof RegExp) {
+    passed = expected.test(caught && caught.error);
+    expected = String(expected);
+  }
+
+  if (typeof expected === 'function' && caught) {
+    passed = caught.error instanceof expected;
+    caught.error = caught.error.constructor;
+  }
+
+  this._assert(typeof fn === 'function' && passed, {
+    message : defined(msg, 'should throw'),
+    operator : 'throws',
+    actual : caught && caught.error,
+    expected : expected,
+    error: !passed && caught && caught.error,
+    extra : extra
+  });
+};
+
+tape.Test.prototype.doesNotThrow = async function (fn, expected, msg, extra) {
+  if (typeof expected === 'string') {
+    msg = expected;
+    expected = undefined;
+  }
+  var caught = undefined;
+  try {
+    await fn();
+  }
+  catch (err) {
+    caught = { error : err };
+  }
+  this._assert(!caught, {
+    message : defined(msg, 'should not throw'),
+    operator : 'throws',
+    actual : caught && caught.error,
+    expected : expected,
+    error : caught && caught.error,
+    extra : extra
+  });
 };

--- a/index.js
+++ b/index.js
@@ -79,26 +79,28 @@ tape.Test.prototype.run = function run() {
   return true;
 };
 
-tape.Test.prototype.throws = async function (fn, expected, msg, extra) {
+tape.Test.prototype.throws = async function(fn, expected, msg, extra) {
+  var caught = undefined;
+  var message = undefined;
+  var passed = undefined;
+
   if (typeof expected === 'string') {
     msg = expected;
     expected = undefined;
   }
 
-  var caught = undefined;
-
   try {
     await fn();
   } catch (err) {
-    caught = { error : err };
-    if ((err != null) && (!isEnumerable(err, 'message') || !has(err, 'message'))) {
-      var message = err.message;
+    caught = { error: err };
+    if ((err !== null) && (!isEnumerable(err, 'message') || !has(err, 'message'))) {
+      message = err.message;
       delete err.message;
       err.message = message;
     }
   }
 
-  var passed = caught;
+  passed = caught;
 
   if (expected instanceof RegExp) {
     passed = expected.test(caught && caught.error);
@@ -111,33 +113,34 @@ tape.Test.prototype.throws = async function (fn, expected, msg, extra) {
   }
 
   this._assert(typeof fn === 'function' && passed, {
-    message : defined(msg, 'should throw'),
-    operator : 'throws',
-    actual : caught && caught.error,
-    expected : expected,
+    message: defined(msg, 'should throw'),
+    operator: 'throws',
+    actual: caught && caught.error,
+    expected: expected,
     error: !passed && caught && caught.error,
-    extra : extra
+    extra: extra
   });
 };
 
-tape.Test.prototype.doesNotThrow = async function (fn, expected, msg, extra) {
+tape.Test.prototype.doesNotThrow = async function(fn, expected, msg, extra) {
+  var caught = undefined;
+
   if (typeof expected === 'string') {
     msg = expected;
     expected = undefined;
   }
-  var caught = undefined;
+
   try {
     await fn();
-  }
-  catch (err) {
-    caught = { error : err };
+  } catch (err) {
+    caught = { error: err };
   }
   this._assert(!caught, {
-    message : defined(msg, 'should not throw'),
-    operator : 'throws',
-    actual : caught && caught.error,
-    expected : expected,
-    error : caught && caught.error,
-    extra : extra
+    message: defined(msg, 'should not throw'),
+    operator: 'throws',
+    actual: caught && caught.error,
+    expected: expected,
+    error: caught && caught.error,
+    extra: extra
   });
 };

--- a/package.json
+++ b/package.json
@@ -15,17 +15,18 @@
   },
   "author": "Andrea Parodi",
   "scripts": {
-    "test": "node test | faucet && eslint ."
+    "test": "node --harmony test | faucet && eslint ."
   },
   "eslintConfig": {
     "extends": [
       "js"
     ],
-    "env": {
-      "es6": true
-    },
+    "env": { "es6": true },
     "parserOptions": {
-      "ecmaVersion": 6
+      "ecmaVersion": 8
+    },
+    "rules" : {
+      "no-param-reassign": "off"
     }
   },
   "babel": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
 const test = require('.');
 const execa = require('execa');
-
+const args = ['--harmony'];
 
 test('support async await functions', function *(t) {
   const result = yield execa('babel-node', ['fixtures/async-await-test']);
@@ -16,7 +16,7 @@ test('test.only is a function', function(t) {
 
 test('support normal cb termination', function *(t) {
   try {
-    yield execa('node', ['fixtures/failing-test']);
+    yield execa('node', args.concat(['fixtures/failing-test']));
     t.fail('Failure expected');
   } catch (err) {
     t.equal(err.stdout.split('\n')[2], 'not ok 1 should be equal');
@@ -26,7 +26,7 @@ test('support normal cb termination', function *(t) {
 
 test('log unhandled exceptions', function *(t) {
   try {
-    yield execa('node', ['fixtures/unhandled-exception-test']);
+    yield execa('node', args.concat(['fixtures/unhandled-exception-test']));
     t.fail('Failure expected');
   } catch (err) {
     t.equal(err.stderr.slice(0, 30), '\nUnhandled exception occurred.');
@@ -35,7 +35,7 @@ test('log unhandled exceptions', function *(t) {
 
 test('log unhandled rejection', function *(t) {
   try {
-    yield execa('node', ['fixtures/unhandled-rejection-test']);
+    yield execa('node', args.concat(['fixtures/unhandled-rejection-test']));
     t.fail('Failure expected');
   } catch (err) {
     t.equal(err.stderr.slice(0, 30), '\nUnhandled rejection occurred.');
@@ -44,7 +44,7 @@ test('log unhandled rejection', function *(t) {
 
 test('log unexpected rejections', function *(t) {
   try {
-    yield execa('node', ['fixtures/unexpected-rejection-test']);
+    yield execa('node', args.concat(['fixtures/unexpected-rejection-test']));
     t.fail('Failure expected');
   } catch (err) {
     t.equal(err.stdout.split('\n')[2], 'not ok 1 Error: unexpected');
@@ -53,7 +53,7 @@ test('log unexpected rejections', function *(t) {
 
 test('log unexpected exceptions', function *(t) {
   try {
-    yield execa('node', ['fixtures/unexpected-exception-test']);
+    yield execa('node', args.concat(['fixtures/unexpected-exception-test']));
     t.fail('Failure expected');
   } catch (err) {
     t.equal(err.stdout.split('\n')[2], 'not ok 1 Error: unexpected');
@@ -62,7 +62,7 @@ test('log unexpected exceptions', function *(t) {
 
 test('log test failures', function *(t) {
   try {
-    yield execa('node', ['fixtures/failing-test']);
+    yield execa('node', args.concat(['fixtures/failing-test']));
     t.fail('Failure expected');
   } catch (err) {
     t.equal(err.stdout.split('\n')[2], 'not ok 1 should be equal');
@@ -70,7 +70,7 @@ test('log test failures', function *(t) {
 });
 
 test('support tests end in cb', function *(t) {
-  const result = yield execa('node', ['fixtures/end-in-cb']);
+  const result = yield execa('node', args.concat(['fixtures/end-in-cb']));
   t.equal(result.stdout, `TAP version 13
 # first test
 first test start


### PR DESCRIPTION
```
const test = require( 'tape-async' )
async function boy() {
  throw new Error('a fit')
}
test( 'example', async function( t ) {
  t.throws( async function() {
    await boy()
  }, /a fit/, 'tape does not catch this error')
  t.end()
}
```

This patch overwrites t.throws and t.doesNotThrow so the above works.
I copied the versions from tape, made them async, changed to await fn();

Seems like something your module would be interested in doing?